### PR TITLE
Upgrading to 1.3.2

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,9 +1,16 @@
 Changelog
 =========
 
+v1.3.2
+------
+- Adding addAttachmentData() and addAttachmentDataToTestStep() to Record class
+- Adding alternative to the setTestStepResult() that requires a lot of interactions
+  with the server. Instead the clearTestStepResults() and appendTestStepResult() methods
+  can be used, and then issuing a save() at the end to commit all
+  the new steps to the server at one go.
 
-V1.3.1 Nuno Brum
-----------------
+V1.3.1
+------
 - Creating PolarionAccessError and PolarionWorkitemAttributeError Exception Classes
 - Adding order parameter to Workitem.moveToDocument() and Document.addHeading() methods
 - Improving debug messages in raised exceptions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 # replace with your username:
 name = polarion
-version = 1.3.0
+version = 1.3.2
 author = Jesper Raemaekers
 author_email = j.raemaekers@relek.nl
 description = Polarion client for Python

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="polarion",
-    version="1.3.1",
+    version="1.3.2",
     author="Jesper Raemaekers",
     author_email="j.raemaekers@relek.nl",
     description="Polarion client for Python",


### PR DESCRIPTION
- Adding addAttachmentData() and addAttachmentDataToTestStep() to Record class
- Adding alternative to the setTestStepResult() that requires a lot of interactions with the server. Instead the clearTestStepResults() and appendTestStepResult() methods can be used, and then issuing a save() at the end to commit all the new steps to the server at one go.